### PR TITLE
Fixed potential NullPointerException in GelfAppender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>gelfj</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>gelfj</name>

--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -116,7 +116,12 @@ public class GelfAppender extends AppenderSkeleton {
         String lineNumber = locationInformation.getLineNumber();
 
         String renderedMessage = event.getRenderedMessage();
-        String shortMessage = "";
+        String shortMessage;
+
+        if(renderedMessage == null) {
+            renderedMessage = "";
+        }
+
         if (renderedMessage.length() > MAX_SHORT_MESSAGE_LENGTH) {
             shortMessage = renderedMessage.substring(0, MAX_SHORT_MESSAGE_LENGTH - 1);
         } else {
@@ -129,7 +134,8 @@ public class GelfAppender extends AppenderSkeleton {
                 renderedMessage += "\n\r" + extractStacktrace(throwableInformation);
             }
         }
-        GelfMessage gelfMessage = new GelfMessage(shortMessage, renderedMessage, timeStamp, level.getSyslogEquivalent() + "", lineNumber, file);
+        GelfMessage gelfMessage = new GelfMessage(shortMessage, renderedMessage, timeStamp,
+                String.valueOf(level.getSyslogEquivalent()), lineNumber, file);
 
         if (getOriginHost() != null) {
             gelfMessage.setHost(getOriginHost());

--- a/src/test/java/org/graylog2/log/GelfAppenderTest.java
+++ b/src/test/java/org/graylog2/log/GelfAppenderTest.java
@@ -5,28 +5,31 @@ import org.apache.log4j.Priority;
 import org.apache.log4j.spi.LoggingEvent;
 import org.graylog2.GelfMessage;
 import org.graylog2.GelfSender;
-import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
  * (c) Copyright: Anton Yakimov
+ *
+ *
  */
 public class GelfAppenderTest {
 
-    @Test
-    public void ensureHostnameForMessage() throws UnknownHostException, SocketException {
+    private TestGelfSender gelfSender;
+    private GelfAppender gelfAppender;
 
-        final TestGelfSender gelfSender = new TestGelfSender("localhost");
+    @Before
+    public void setUp() throws UnknownHostException, SocketException {
+        gelfSender = new TestGelfSender("localhost");
 
-        GelfAppender gelfAppender = new GelfAppender() {
+        gelfAppender = new GelfAppender() {
 
             @Override
             public GelfSender getGelfSender() {
@@ -38,8 +41,22 @@ public class GelfAppenderTest {
                 super.append(event);
             }
         };
+    }
+
+    @Test
+    public void ensureHostnameForMessage() {
 
         LoggingEvent event = new LoggingEvent("a.b.c.DasClass", Category.getInstance(this.getClass()), 123L, Priority.INFO, "Das Auto", new RuntimeException("LOL"));
+        gelfAppender.append(event);
+
+        assertThat("Message short message", gelfSender.getLastMessage().getShortMessage(), notNullValue());
+        assertThat("Message full message", gelfSender.getLastMessage().getFullMessage(), notNullValue());
+    }
+
+    @Test
+    public void handleNullInAppend() throws UnknownHostException, SocketException {
+
+        LoggingEvent event = new LoggingEvent("a.b.c.DasClass", Category.getInstance(this.getClass()), 123L, Priority.INFO, null, new RuntimeException("LOL"));
         gelfAppender.append(event);
 
         assertThat("Message hostname", gelfSender.getLastMessage().getHost(), notNullValue());


### PR DESCRIPTION
GelfAppender#append will throw a NullPointerException if LogEvent.message is null. Added check to prevent this condition and log an empty message instead.
