### PR TITLE
Fixing (in our case critical) NPE case, where activateOptions() gets called before adding appender to rootLogger, but still getSender() is null

### DIFF
--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -197,7 +197,7 @@ public class GelfAppender extends AppenderSkeleton {
             }
         }
 
-        if(!getGelfSender().sendMessage(gelfMessage)) {
+        if(getGelfSender() == null || !getGelfSender().sendMessage(gelfMessage)) {
             errorHandler.error("Could not send GELF message");
         }
     }


### PR DESCRIPTION
fix NPE during intialization. GelfAppender doesn't seem to be thread-safe, activateOptions() vs. sendMessage() calls collide (i.e. getSender() was 'null'. Server startup got messed up this way
