### PR TITLE
update of pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>gelfj</artifactId>
-    <version>0.8</version>
+    <version>0.8.1</version>
     <packaging>jar</packaging>
 
     <name>gelfj</name>


### PR DESCRIPTION
sorry, with bug-fix forgot to upgrade pom.xml. The version has to be increased because 0.8 is already released and distributed in our maven-distribution-servers (no way to update dependencies for non-SNAPSHOT version). I changed to three-digit 0.8.1 to identify a minor fix.
