### PR TITLE
Sound handling of originHost in GelfAppender

### DIFF
--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class GelfAppender extends AppenderSkeleton implements GelfMessageProvider {
 
     private String graylogHost;
-    private String originHost;
+    private static String originHost;
     private int graylogPort = 12201;
     private String facility;
     private GelfSender gelfSender;
@@ -40,18 +40,6 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
 
     public GelfAppender() {
         super();
-        this.originHost = getLocalHostName();
-    }
-
-    private String getLocalHostName() {
-        String hostName = null;
-        try {
-            hostName = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            errorHandler.error("Unknown local hostname", e, ErrorCode.GENERIC_FAILURE);
-        }
-
-        return hostName;
     }
 
     public void setAdditionalFields(String additionalFields) {
@@ -90,11 +78,11 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
         this.extractStacktrace = extractStacktrace;
     }
 
-    public String getOriginHost() {
+    public static String getOriginHost() {
         return originHost;
     }
 
-    public void setOriginHost(String originHost) {
+    public static void setOriginHost(String originHost) {
         this.originHost = originHost;
     }
 

--- a/src/main/java/org/graylog2/log/GelfConsoleAppender.java
+++ b/src/main/java/org/graylog2/log/GelfConsoleAppender.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class GelfConsoleAppender extends ConsoleAppender implements GelfMessageProvider{
     
-    private String originHost;
+    private static String originHost;
     private boolean extractStacktrace;
     private boolean addExtendedInformation;
     private Map<String, String> fields;
@@ -66,11 +66,11 @@ public class GelfConsoleAppender extends ConsoleAppender implements GelfMessageP
         this.addExtendedInformation = addExtendedInformation;
     }
     
-    public String getOriginHost() {
+    public static String getOriginHost() {
         return originHost;
     }
 
-    public void setOriginHost(String originHost) {
+    public static void setOriginHost(String originHost) {
         this.originHost = originHost;
     }
 


### PR DESCRIPTION
I removed the getLocalHostName() method call in the constructur of GelfAppender. I did this because on my local machine this called resulted in an exception due to the local hostname could not be resolved. As such a scenario might also be happening in a production environment I propose that the originHost should be set via a static method. For this I changed the classes GelfAppender and GelfConsoleAppender.
