### PR TITLE
patch to add the thread name to gelf message

### DIFF
--- a/src/main/java/org/graylog2/GelfMessageFactory.java
+++ b/src/main/java/org/graylog2/GelfMessageFactory.java
@@ -16,6 +16,7 @@ public class GelfMessageFactory {
     private static final String ORIGIN_HOST_KEY = "originHost";
     private static final String LOGGER_NAME = "logger";
     private static final String LOGGER_NDC = "loggerNdc";
+    private static final String THREAD_NAME = "thread";
     private static final String JAVA_TIMESTAMP = "timestampMs";
     
     public static final GelfMessage makeMessage(LoggingEvent event, GelfMessageProvider provider) {
@@ -69,6 +70,7 @@ public class GelfMessageFactory {
 
         if (provider.isAddExtendedInformation()) {
 
+            gelfMessage.addField(THREAD_NAME, event.getThreadName());
             gelfMessage.addField(LOGGER_NAME, event.getLoggerName());
             gelfMessage.addField(JAVA_TIMESTAMP, Long.toString(gelfMessage.getJavaTimestamp()));
 


### PR DESCRIPTION
trivial patch to add the thread name to gelf message only when addExtendedInfo is true

let me know if you'd rather have it as an optional field and i'll add the config parameters.
