### PR TITLE
Made the build work with the latest verison of gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 dependencies {
-  compile 'junit:junit:4.9'  
+  testCompile 'junit:junit:4.9'  
   compile "log4j:log4j:1.2.7@jar"
   compile "com.googlecode.json-simple:json-simple:1.1"
 }
 
-task libDir(dependsOn: configurations.runtime.buildArtifacts, type: Copy) {
+task libDir(dependsOn: assemble, type: Copy) {
   into('lib')
   from configurations.runtime
   from configurations.runtime.allArtifacts.file


### PR DESCRIPTION
Had to change the libDir dependency to get the build working with 1.0-milestone-9 of Gradle. I also took the chance to change the configuration for junit to testCompile.

I just realized that you might want junit to end up in when you run libDir, that's not the case now. Would you like me to fix that?
