### PR TITLE
Added 'includeLocationInformation' parameter

### DIFF
--- a/src/main/java/org/graylog2/GelfMessageFactory.java
+++ b/src/main/java/org/graylog2/GelfMessageFactory.java
@@ -9,6 +9,7 @@ import org.graylog2.log.Log4jVersionChecker;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Date;
 import java.util.Map;
 
 public class GelfMessageFactory {
@@ -22,10 +23,6 @@ public class GelfMessageFactory {
     public static final GelfMessage makeMessage(LoggingEvent event, GelfMessageProvider provider) {
         long timeStamp = Log4jVersionChecker.getTimeStamp(event);
         Level level = event.getLevel();
-
-        LocationInfo locationInformation = event.getLocationInformation();
-        String file = locationInformation.getFileName();
-        String lineNumber = locationInformation.getLineNumber();
 
         String renderedMessage = event.getRenderedMessage();
         String shortMessage;
@@ -48,8 +45,18 @@ public class GelfMessageFactory {
             }
         }
         
-        GelfMessage gelfMessage = new GelfMessage(shortMessage, renderedMessage, timeStamp,
-                                                  String.valueOf(level.getSyslogEquivalent()), lineNumber, file);
+        GelfMessage gelfMessage;
+
+        if (provider.isIncludeLocationInformation()) {
+            LocationInfo locationInformation = event.getLocationInformation();
+            String file = locationInformation.getFileName();
+            String lineNumber = locationInformation.getLineNumber();
+
+            gelfMessage = new GelfMessage(shortMessage, renderedMessage, timeStamp, String.valueOf(level.getSyslogEquivalent()), lineNumber, file);
+        }
+        else {
+            gelfMessage =  new GelfMessage(shortMessage, renderedMessage, new Date(timeStamp), String.valueOf(level.getSyslogEquivalent()));
+        }
         
         if (provider.getOriginHost() != null) {
             gelfMessage.setHost(provider.getOriginHost());

--- a/src/main/java/org/graylog2/GelfMessageProvider.java
+++ b/src/main/java/org/graylog2/GelfMessageProvider.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public interface GelfMessageProvider {
     public boolean isExtractStacktrace();
+    public boolean isIncludeLocationInformation();
     public String getOriginHost();
     public String getFacility();
     public Map<String, String> getFields();

--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -35,6 +35,7 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
     private String facility;
     private GelfSender gelfSender;
     private boolean extractStacktrace;
+    private boolean includeLocationInformation;
     private boolean addExtendedInformation;
     private Map<String, String> fields;
 
@@ -76,6 +77,14 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
 
     public void setExtractStacktrace(boolean extractStacktrace) {
         this.extractStacktrace = extractStacktrace;
+    }
+
+    public boolean isIncludeLocationInformation() {
+        return includeLocationInformation;
+    }
+
+    public void setIncludeLocationInformation(boolean includeLocationInformation) {
+        this.includeLocationInformation = includeLocationInformation;
     }
 
     public String getOriginHost() {

--- a/src/main/java/org/graylog2/log/GelfConsoleAppender.java
+++ b/src/main/java/org/graylog2/log/GelfConsoleAppender.java
@@ -29,6 +29,7 @@ public class GelfConsoleAppender extends ConsoleAppender implements GelfMessageP
     private boolean extractStacktrace;
     private boolean addExtendedInformation;
     private Map<String, String> fields;
+    private boolean locationInformation;
     
     // parent overrides.
     
@@ -64,6 +65,14 @@ public class GelfConsoleAppender extends ConsoleAppender implements GelfMessageP
 
     public void setAddExtendedInformation(boolean addExtendedInformation) {
         this.addExtendedInformation = addExtendedInformation;
+    }
+
+    public boolean isIncludeLocationInformation() {
+        return locationInformation;
+    }
+
+    public void setIncludeLocationInformation(boolean locationInformation) {
+        this.locationInformation = locationInformation;
     }
     
     public String getOriginHost() {


### PR DESCRIPTION
Made an additional parameter 'includeLocationInformation' that allows configuration for including file and lineNumber or excluding them. On some rough testing, turning off file name and line number as part of a GelfMessage means saving approximately 50% of the time required to create and send the message, primarily because of the long execution time to get LocationInfo out of an event.
