### PR TITLE
Chunks are sent incorrectly

### DIFF
--- a/src/main/java/org/graylog2/GelfSender.java
+++ b/src/main/java/org/graylog2/GelfSender.java
@@ -38,7 +38,9 @@ public class GelfSender {
 
 	public boolean sendDatagrams(ByteBuffer[] bytesList) {
             try {
-				channel.write(bytesList);
+				for (ByteBuffer buffer : bytesList) {
+                    channel.write(buffer);
+                }
             } catch (IOException e) {
                 return false;
             }


### PR DESCRIPTION
When  a chunked message is sent to graylog2 server the server will never beable to decode it:

```
2012-11-01 11:18:45,742 DEBUG: org.graylog2.messagehandlers.gelf.ChunkedGELFClientHandler - Got GELF message chunk: GELFClientChunk:
    Hash: bbb1b89a6c657373  Sequence: 0/4   Arrival: 1351768725 Data size: 4802
```

As you can see the datasize is larger than the max chunk-size, this because of the automatic concatting of the `ByteBuffer`s in the `channel.write()`

Will submit a pull request resolving the issue making the request in graylog2 look like:

```
2012-11-01 11:21:38,017 DEBUG: org.graylog2.messagehandlers.gelf.GELFClientHandlerThread - Received message is chunked. Handling now.
2012-11-01 11:21:38,017 DEBUG: org.graylog2.messagehandlers.gelf.ChunkedGELFClientHandler - Got GELF message chunk: GELFClientChunk:
    Hash: bbb459916c657373  Sequence: 0/4   Arrival: 1351768898 Data size: 1420
2012-11-01 11:21:38,018 DEBUG: org.graylog2.messagehandlers.gelf.GELFClientHandlerThread - Received message is chunked. Handling now.
2012-11-01 11:21:38,018 DEBUG: org.graylog2.messagehandlers.gelf.ChunkedGELFClientHandler - Got GELF message chunk: GELFClientChunk:
    Hash: bbb459916c657373  Sequence: 1/4   Arrival: 1351768898 Data size: 1420
2012-11-01 11:21:38,019 DEBUG: org.graylog2.messagehandlers.gelf.GELFClientHandlerThread - Received message is chunked. Handling now.
2012-11-01 11:21:38,019 DEBUG: org.graylog2.messagehandlers.gelf.ChunkedGELFClientHandler - Got GELF message chunk: GELFClientChunk:
    Hash: bbb459916c657373  Sequence: 2/4   Arrival: 1351768898 Data size: 1420
2012-11-01 11:21:38,019 DEBUG: org.graylog2.messagehandlers.gelf.GELFClientHandlerThread - Received message is chunked. Handling now.
2012-11-01 11:21:38,020 DEBUG: org.graylog2.messagehandlers.gelf.ChunkedGELFClientHandler - Got GELF message chunk: GELFClientChunk:
    Hash: bbb459916c657373  Sequence: 3/4   Arrival: 1351768898 Data size: 504
```
