### PR TITLE
GelfMessageFactory built an invalid message

### DIFF
--- a/src/main/java/org/graylog2/GelfMessageFactory.java
+++ b/src/main/java/org/graylog2/GelfMessageFactory.java
@@ -38,18 +38,18 @@ public class GelfMessageFactory {
             renderedMessage = "";
         }
 
-        if (renderedMessage.length() > MAX_SHORT_MESSAGE_LENGTH) {
-            shortMessage = renderedMessage.substring(0, MAX_SHORT_MESSAGE_LENGTH - 1);
-        }
-        else {
-            shortMessage = renderedMessage;
-        }
-
         if (provider.isExtractStacktrace()) {
             ThrowableInformation throwableInformation = event.getThrowableInformation();
             if (throwableInformation != null) {
                 renderedMessage += "\n\r" + extractStacktrace(throwableInformation);
             }
+        }
+        
+        if (renderedMessage.length() > MAX_SHORT_MESSAGE_LENGTH) {
+            shortMessage = renderedMessage.substring(0, MAX_SHORT_MESSAGE_LENGTH - 1);
+        }
+        else {
+            shortMessage = renderedMessage;
         }
         
         GelfMessage gelfMessage = new GelfMessage(shortMessage, renderedMessage, timeStamp,


### PR DESCRIPTION
GelfMessageFactory built an invalid message (empty short message) when extractStacktrace was enabled and the logging event didn't have a rendered message. This prevented the message from being sent.
