### PR TITLE
Added a way to transform data from the MDC context before passed on.

### DIFF
--- a/src/main/java/org/graylog2/GelfMessageFactory.java
+++ b/src/main/java/org/graylog2/GelfMessageFactory.java
@@ -85,7 +85,8 @@ public class GelfMessageFactory {
 
             if (mdc != null) {
                 for (Map.Entry<String, Object> entry : mdc.entrySet()) {
-                    gelfMessage.addField(entry.getKey(), entry.getValue().toString());
+                    Object value = provider.transformExtendedField(entry.getKey(), entry.getValue());
+                    gelfMessage.addField(entry.getKey(), value);
                 }
             }
 

--- a/src/main/java/org/graylog2/GelfMessageProvider.java
+++ b/src/main/java/org/graylog2/GelfMessageProvider.java
@@ -9,4 +9,5 @@ public interface GelfMessageProvider {
     public Map<String, String> getFields();
     public boolean isAddExtendedInformation();
     public boolean isIncludeLocation();
+    public Object transformExtendedField(String field, Object object);
 }

--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.graylog2.*;
 
 /**
@@ -158,6 +159,13 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
             fields = new HashMap<String, String>();
         }
         return Collections.unmodifiableMap(fields);
+    }
+    
+    @Override
+    public Object transformExtendedField(String field, Object object) {
+        if (object != null)
+            return object.toString();
+        return null;
     }
 
     @Override

--- a/src/main/java/org/graylog2/log/GelfConsoleAppender.java
+++ b/src/main/java/org/graylog2/log/GelfConsoleAppender.java
@@ -93,6 +93,13 @@ public class GelfConsoleAppender extends ConsoleAppender implements GelfMessageP
         }
         return Collections.unmodifiableMap(fields);
     }
+    
+    @Override
+    public Object transformExtendedField(String field, Object object) {
+        if (object != null)
+            return object.toString();
+        return null;
+    }
 
     // the important parts.
 


### PR DESCRIPTION
I would like to add meta data fields that are numeric to Graylog2 by using the MDC context so that I can search on these fields as numbers and not strings. 

Basically we have log statements that set the time that something took in the MDC context as well as other numeric metrics. The current implementation always converts MDC context fields into strings which is actually more or less the right thing to do since SLF4J only supports Strings in the MDC. However I would like to convert those numeric Strings back into numbers by extending the Appender to handle my special fields. 

I tried to make as minimal change as I could while also providing a unit test.
