### PR TITLE
Use value comparison when checking log levels.

### DIFF
--- a/src/main/java/org/graylog2/logging/GelfHandler.java
+++ b/src/main/java/org/graylog2/logging/GelfHandler.java
@@ -283,15 +283,15 @@ public class GelfHandler
     private int levelToSyslogLevel( final Level level )
     {
         final int syslogLevel;
-        if ( level == Level.SEVERE )
+        if ( level.intValue() == Level.SEVERE.intValue() )
         {
             syslogLevel = 3;
         }
-        else if ( level == Level.WARNING )
+        else if ( level.intValue() == Level.WARNING.intValue() )
         {
             syslogLevel = 4;
         }
-        else if ( level == Level.INFO )
+        else if ( level.intValue() == Level.INFO.intValue() )
         {
             syslogLevel = 6;
         }


### PR DESCRIPTION
The passed in log level is not always one of the static instances provided. Compare against the intValue of the log Level to determine equality.
