### PR TITLE
Sending TCP Messages will now block until sent

### DIFF
--- a/src/main/java/org/graylog2/GelfTCPSender.java
+++ b/src/main/java/org/graylog2/GelfTCPSender.java
@@ -2,7 +2,6 @@ package org.graylog2;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PipedOutputStream;
 import java.net.*;
 
 public class GelfTCPSender implements GelfSender {


### PR DESCRIPTION
Previously, the Graylog server could drop messages, as messages could be sent without acknowledgment of receipt. I think that they will now not drop, as the output stream would be in use.

Happy to test this further tomorrow.
