### PR TITLE
implement gelf 1.1 spec

### DIFF
--- a/src/main/java/org/graylog2/GelfMessage.java
+++ b/src/main/java/org/graylog2/GelfMessage.java
@@ -15,7 +15,7 @@ import java.util.zip.GZIPOutputStream;
 public class GelfMessage {
 
     private static final String ID_NAME = "id";
-    private static final String GELF_VERSION = "1.0";
+    private static final String GELF_VERSION = "1.1";
     private static final byte[] GELF_CHUNKED_ID = new byte[]{0x1e, 0x0f};
     private static final int MAXIMUM_CHUNK_SIZE = 1420;
     private static final BigDecimal TIME_DIVISOR = new BigDecimal(1000);
@@ -39,7 +39,7 @@ public class GelfMessage {
         this(shortMessage, fullMessage, timestamp, level, null, null);
     }
 
-    public GelfMessage(String shortMessage, String fullMessage, Long timestamp, String level, String line, String file) {
+    public GelfMessage(String shortMessage, String fullMessage, long timestamp, String level, String line, String file) {
         this.shortMessage = shortMessage;
         this.fullMessage = fullMessage;
         this.javaTimestamp = timestamp;
@@ -57,13 +57,22 @@ public class GelfMessage {
         map.put("full_message", getFullMessage());
         map.put("timestamp", getTimestamp());
 
-        map.put("level", getLevel());
         map.put("facility", getFacility());
+        try {
+            map.put("level", Long.parseLong(getLevel()));
+        } catch (NumberFormatException e) {
+            map.put("level", 6L); // fallback to info
+        }
+
         if (null != getFile()) {
             map.put("file", getFile());
         }
         if (null != getLine()) {
-            map.put("line", getLine());
+            try {
+                map.put("line", Long.parseLong(getLine()));
+            } catch (NumberFormatException e) {
+                map.put("line", -1L);
+            }
         }
 
         for (Map.Entry<String, Object> additionalField : additonalFields.entrySet()) {

--- a/src/test/java/org/graylog2/GelfMessageTest.java
+++ b/src/test/java/org/graylog2/GelfMessageTest.java
@@ -1,6 +1,7 @@
 package org.graylog2;
 
 import org.json.simple.JSONValue;
+import org.json.simple.JSONObject;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -64,7 +65,7 @@ public class GelfMessageTest {
 
     @Test
     public void testEmptyShortMessage() {
-        GelfMessage message = new GelfMessage(null, "Long message", 1L, "INFO");
+        GelfMessage message = new GelfMessage(null, "Long message", 1L, "1");
         message.setHost("localhost");
         message.setVersion("0.0");
 
@@ -77,5 +78,15 @@ public class GelfMessageTest {
         message.setShortMessage("Hamburg");
         message.setFullMessage(null);
         assertThat("Valid when short message is set", message.isValid(), is(true));
+    }
+
+    @Test
+    public void testInvalidLevelMessage() {
+        GelfMessage message = new GelfMessage("Short", "Long", 1L, "WARNING");
+        message.setHost("localhost");
+
+        JSONObject object = (JSONObject) JSONValue.parse(message.toJson());
+
+        assertThat("Message with invalid level defaults to info", (Long) object.get("level"), is(6L));
     }
 }


### PR DESCRIPTION
implement gelf 1.1 spec according to the column types. does not remove fields marked as deprecated, since this is a too big change

http://graylog2.org/gelf#specs
