### PR TITLE
OSGI Bundle support in the POM and JRE version update to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Gelfj - Changelog
 =================
 
+Release 1.1.9
+-------------
+
+2015-03-26
+
+   ENH: (@mmuruganandam) Enabled the support for OSGI bundling.  Updated the Maven POM to be compatible with 1.6 and above for @Override issues with 1.5.
+
 Release 1.1.7
 -------------
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,22 +2,37 @@ buildscript {
   repositories {
     maven { url "http://repo.springsource.org/plugins-release" }
   }
+  
   dependencies {
     classpath("org.springframework.build.gradle:propdeps-plugin:0.0.5")
+	classpath 'org.dm.gradle:gradle-bundle-plugin:0.6.2'
   }
 }
 
 apply plugin: 'java'
 apply plugin: 'propdeps'
 apply plugin: 'propdeps-maven'
+apply plugin: 'org.dm.bundle'
 
+group = 'org.graylog2.gelfj'
+sourceCompatibility = 1.5
+version = '1.1.9-SNAPSHOT'
 
-sourceCompatibility = 1.6
-version = '1.1.8-SNAPSHOT'
 jar {
-  manifest {
-    attributes 'Implementation-Title': 'GELF Java Implementation', 'Implementation-Version': version
-  }
+	manifest {
+		attributes 'Implementation-Title': 'GELF Java Implementation', 
+			'Implementation-Version': project.version, 
+			'Import-Package': '!*',
+			'Private-Package': '*',
+			'Export-Package': 'org.graylog2;org.graylog2.*',
+			'Bundle-Name': project.group,
+			'Bundle-SymbolicName': project.group,
+			'Embed-Dependency': '*;scope=compile|runtime;inline=true',
+			'Fragment-Host' : 'org.ops4j.pax.logging.pax-logging-service'
+	}
+	doFirst {
+		from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
+	}
 }
 
 repositories {
@@ -29,7 +44,7 @@ dependencies {
   testCompile 'com.google.guava:guava:18.0-rc1'
   compile "log4j:log4j:1.2.17@jar"
   compile "com.googlecode.json-simple:json-simple:1.1"
-  optional "com.rabbitmq:amqp-client:3.0.4"
+  compile "com.rabbitmq:amqp-client:3.0.4"
 }
 
 task libDir(dependsOn: assemble, type: Copy) {

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
     <groupId>org.graylog2</groupId>
     <artifactId>gelfj</artifactId>
     <version>1.1.9-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>gelfj</name>
     <description>GELF implementation in Java and log4j appender without any dependencies.</description>
     <url>https://github.com/t0xa/gelfj</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.5</java.version>
+        <java.version>1.6</java.version>
     </properties>
 
     <licenses>
@@ -150,6 +150,22 @@
                     </execution>
                 </executions>
             </plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.5</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-Name>${project.groupId}.${project.artifactId}</Bundle-Name>
+						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+						<Import-Package>!*</Import-Package>
+						<Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
+						<Fragment-Host>org.ops4j.pax.logging.pax-logging-service</Fragment-Host>
+						<Implementation-Version>${project.version}</Implementation-Version>
+					</instructions>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.6</java.version>
+        <java.version>1.5</java.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
There are lot of Application servers and other tools using OSGI framework these days.  It is very nice to have that enabled out of the box rather than allowing people to create their own version of gelfj.

Also updated the JRE compatibility to 1.6 as @Override is failing with JRE 1.5 compatibility.  I see that it is already updated in the gradle build but not in the POM.