### PR TITLE
UDP buffer size error

### DIFF
--- a/src/main/java/org/graylog2/GelfMessage.java
+++ b/src/main/java/org/graylog2/GelfMessage.java
@@ -146,9 +146,9 @@ public class GelfMessage {
             if (to >= messageLength) {
                 to = messageLength;
             }
-            
-            byte[] range = new byte[(to - from) + 1];
-            System.arraycopy(messageBytes, from, range, 0, (range.length - 1));            
+
+            byte[] range = new byte[to - from];
+            System.arraycopy(messageBytes, from, range, 0, range.length);
             
             byte[] datagram = concatByteArray(header, range);
             datagrams[idx] = ByteBuffer.allocate(datagram.length);


### PR DESCRIPTION
When a message is split into multiple UDP datagrams GrayLog fails to decompress it. This is caused by the 'range' buffer being too large by one byte. This fixes the issue. Tested with release 1.1.12.