### PR TITLE
Allow Appenders and Handlers to pass a zero length message to network

### DIFF
--- a/src/main/java/org/graylog2/GelfMessage.java
+++ b/src/main/java/org/graylog2/GelfMessage.java
@@ -40,7 +40,7 @@ public class GelfMessage {
     }
 
     public GelfMessage(String shortMessage, String fullMessage, long timestamp, String level, String line, String file) {
-        this.shortMessage = shortMessage;
+        this.shortMessage = shortMessage != null ? shortMessage : "null";
         this.fullMessage = fullMessage;
         this.javaTimestamp = timestamp;
         this.level = level;
@@ -210,7 +210,7 @@ public class GelfMessage {
     }
 
     public String getShortMessage() {
-        return !isEmpty(shortMessage) ? shortMessage : "<empty>";
+        return shortMessage;
     }
 
     public void setShortMessage(String shortMessage) {
@@ -292,7 +292,7 @@ public class GelfMessage {
     }
 
     private boolean isShortOrFullMessagesExists() {
-        return !isEmpty(shortMessage) || !isEmpty(fullMessage);
+        return shortMessage != null || fullMessage != null;
     }
 
     public boolean isEmpty(String str) {

--- a/src/test/java/org/graylog2/GelfMessageTest.java
+++ b/src/test/java/org/graylog2/GelfMessageTest.java
@@ -88,14 +88,26 @@ public class GelfMessageTest {
         message.setVersion("0.0");
 
         assertThat("Message with empty short message is Valid", message.isValid(), is(true));
-        assertThat("Short message is set to <empty> when null", message.getShortMessage(), is("<empty>"));
+        assertThat("Short message is set to 'null' when null", message.getShortMessage(), is("null"));
 
         message.setFullMessage(null);
-        assertThat("Not valid when not full message set nor short message set", message.isValid(), is(false));
+        assertThat("An empty message is valid (neither full nor short message set)", message.isValid(), is(true));
 
         message.setShortMessage("Hamburg");
         message.setFullMessage(null);
         assertThat("Valid when short message is set", message.isValid(), is(true));
+    }
+
+    @Test
+    public void testZeroLengthMessage() {
+        GelfMessage message = new GelfMessage("", "", 1L, "1");
+
+        message.setHost("localhost");
+        message.setVersion("0.0");
+        assertThat("Message with a zero length short message is Valid",
+          message.isValid(), is(true));
+        assertThat("Short message is set to an empty string when zero length",
+          message.getShortMessage(), is(""));
     }
 
     @Test


### PR DESCRIPTION
This change allows both Appenders (org.apache.log4j.Appender) and Handlers
(java.util.logging.Handler) to send zero length and null messages to
a remote destination. Previously both zero length and null messages were
pruned out in GelfMessage class.

Though pruning out empty messages makes sense in terms of saving (some)
network traffic, it's kind of counterintuitive for several reasons.

To begin with, those who are familiar with other implementations expect
to see an empty message to get passed along. E.g. o.a.l.ConsoleAppender,
o.a.l.FileAppender, j.u.l.ConsoleHandler, and j.u.l.FileHandler all
allow a zero length/null message to be passed on.

Additionally, an Appender/Handler implementation is not supposed to
prune out any messages, besides invalid ones which simply can not be
passed due to missing information. In this case an empty message is
not something that prevents it being sent, as long as other GELF
parameters are all right. If additional filtering is needed, that should
go in org.apache.log4j.Filter or java.util.logging.Filter implementation
respectively.

Finally, there is a use case for sending empty messages as well. Some
developer might want to do log.info(thisStringIGotPassed), and should
the string be empty, it'd be reasonable to expect an empty log entry
appear, instead of receiving an error "Could not send GELF message".

References:

https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Appender.html
https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/spi/Filter.html

https://docs.oracle.com/javase/7/docs/api/java/util/logging/Filter.html
https://docs.oracle.com/javase/7/docs/api/java/util/logging/Handler.html