### PR TITLE
Tcp delimiter

### DIFF
--- a/src/main/java/org/graylog2/GelfMessage.java
+++ b/src/main/java/org/graylog2/GelfMessage.java
@@ -1,5 +1,6 @@
 package org.graylog2;
 
+import org.graylog2.constants.TCPDelimiter;
 import org.json.simple.JSONValue;
 
 import java.io.ByteArrayOutputStream;
@@ -104,14 +105,14 @@ public class GelfMessage {
         return datagrams;
     }
 
-    public ByteBuffer toTCPBuffer() {
+    public ByteBuffer toTCPBuffer(TCPDelimiter delimiter) {
         byte[] messageBytes;
         try {
             // Do not use GZIP, as the headers will contain \0 bytes
             // graylog2-server uses \0 as a delimiter for TCP frames
             // see: https://github.com/Graylog2/graylog2-server/issues/127
             String json = toJson() ;
-            json += '\0';
+            json += delimiter.toString();
             messageBytes = json.getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("No UTF-8 support available.", e);

--- a/src/main/java/org/graylog2/GelfTCPSender.java
+++ b/src/main/java/org/graylog2/GelfTCPSender.java
@@ -18,7 +18,7 @@ public class GelfTCPSender implements GelfSender {
     {
     	this.host = InetAddress.getByName(tcpGraylogHost);
 		this.port = graylogPort;
-		this.socket = new Socket(tcpGraylogHost, port);
+		this.socket = new Socket(this.host, port);
         this.os = socket.getOutputStream();
         this.delimiter = getTcpDelimiter(delimiter);
     }

--- a/src/main/java/org/graylog2/constants/TCPDelimiter.java
+++ b/src/main/java/org/graylog2/constants/TCPDelimiter.java
@@ -1,0 +1,19 @@
+package org.graylog2.constants;
+
+public enum TCPDelimiter
+{
+  NULL("\0"),NEWLINE("\n");
+	
+  private final String delimiter;
+  
+  TCPDelimiter(String delimiter)
+  {
+	  this.delimiter = delimiter;
+  }
+  
+  @Override
+  public String toString() 
+  {
+      return delimiter;
+  }
+}

--- a/src/main/java/org/graylog2/log/GelfAppender.java
+++ b/src/main/java/org/graylog2/log/GelfAppender.java
@@ -7,6 +7,7 @@ import org.graylog2.GelfMessage;
 import org.graylog2.GelfMessageFactory;
 import org.graylog2.GelfMessageProvider;
 import org.graylog2.GelfSender;
+import org.graylog2.constants.TCPDelimiter;
 import org.json.simple.JSONValue;
 
 import java.io.IOException;
@@ -42,6 +43,8 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
     private boolean addExtendedInformation;
     private boolean includeLocation = true;
     private Map<String, String> fields;
+    private TCPDelimiter delimiter;
+
 
     public GelfAppender() {
         super();
@@ -161,6 +164,20 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
         return Collections.unmodifiableMap(fields);
     }
     
+    /**
+	 * @return the delimiter
+	 */
+	public TCPDelimiter getTCPDelimiter() {
+		return delimiter;
+	}
+
+	/**
+	 * @param delimiter the delimiter to set
+	 */
+	public void setTCPDelimiter(TCPDelimiter delimiter) {
+		this.delimiter = delimiter;
+	}
+	
     public Object transformExtendedField(String field, Object object) {
         if (object != null)
             return object.toString();
@@ -177,7 +194,7 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
             try {
                 if (graylogHost != null && graylogHost.startsWith("tcp:")) {
                     String tcpGraylogHost = graylogHost.substring(4);
-                    gelfSender = getGelfTCPSender(tcpGraylogHost, graylogPort);
+                    gelfSender = getGelfTCPSender(tcpGraylogHost, graylogPort, delimiter);
                 } else if (graylogHost != null && graylogHost.startsWith("udp:")) {
                     String udpGraylogHost = graylogHost.substring(4);
                     gelfSender = getGelfUDPSender(udpGraylogHost, graylogPort);
@@ -206,6 +223,11 @@ public class GelfAppender extends AppenderSkeleton implements GelfMessageProvide
         return new GelfUDPSender(udpGraylogHost, graylogPort);
     }
 
+    
+    protected GelfTCPSender getGelfTCPSender(String tcpGraylogHost, int graylogPort, TCPDelimiter delimiter) throws IOException {
+        return new GelfTCPSender(tcpGraylogHost, graylogPort, delimiter);
+    }
+    
     protected GelfTCPSender getGelfTCPSender(String tcpGraylogHost, int graylogPort) throws IOException {
         return new GelfTCPSender(tcpGraylogHost, graylogPort);
     }


### PR DESCRIPTION
For GELF-TCP input, null delimiter (\0) is not always correct. New line character is the default delimiter. Added delimiter property to GelfAppender class to make this configurable. It's optional and make sense only if chosen protocol is TCP.  If it's not provided, null delimiter is default.