### PR TITLE
Removed caching of the DNS resolution - the code will now rely on the…

### DIFF
--- a/src/main/java/org/graylog2/GelfTCPSender.java
+++ b/src/main/java/org/graylog2/GelfTCPSender.java
@@ -2,11 +2,11 @@ package org.graylog2;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.*;
+import java.net.Socket;
 
 public class GelfTCPSender implements GelfSender {
 	private boolean shutdown = false;
-	private InetAddress host;
+	private String host;
 	private int port;
 	private Socket socket;
     private OutputStream os;
@@ -15,7 +15,7 @@ public class GelfTCPSender implements GelfSender {
     }
 
 	public GelfTCPSender(String host, int port) throws IOException {
-		this.host = InetAddress.getByName(host);
+		this.host = host;
 		this.port = port;
 		this.socket = new Socket(host, port);
         this.os = socket.getOutputStream();

--- a/src/main/java/org/graylog2/GelfUDPSender.java
+++ b/src/main/java/org/graylog2/GelfUDPSender.java
@@ -14,7 +14,7 @@ public class GelfUDPSender implements GelfSender {
 	private Date lastChannelRefresh = null;
 
 	private static final int MAX_RETRIES = 5;
-	private static final int REFRESH_CHANNEL_SECONDS = 30;
+	private static final int REFRESH_CHANNEL_SECONDS = 300;
 
     public GelfUDPSender() {
     }


### PR DESCRIPTION
… JVM's cache instead and rely on the networkaddress.cache.ttl security property;

For the UDP sender, also added a refresh of the channel every 5 minutes - otherwise the same channel would keep sending to the same IP forever.

Signed-off-by: Gaspard Petit <gaspard.petit@eidosmontreal.com>